### PR TITLE
Clean up uploaded files after processing

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,6 +42,7 @@ def extract_text(file_storage):
         doc = docx.Document(filepath)
         for para in doc.paragraphs:
             text += para.text + "\n"
+    os.remove(filepath)
     return text
 
 def extract_keywords(text, top_k=20):
@@ -126,7 +127,9 @@ def builder():
 
         file_path = os.path.join(UPLOAD_FOLDER, "built_resume.pdf")
         pdf.output(file_path)
-        return send_file(file_path, as_attachment=True)
+        response = send_file(file_path, as_attachment=True)
+        os.remove(file_path)
+        return response
 
     return render_template("builder.html")
 


### PR DESCRIPTION
## Summary
- delete uploaded resume/JD files after text extraction
- remove generated resume PDF once it's sent to the client

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68419656cd8c832c8e6200c5076b0f52