### PR TITLE
Add configuration module

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,11 +10,11 @@ import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
 from fpdf import FPDF
+from config import DefaultConfig
 
 app = Flask(__name__)
-UPLOAD_FOLDER = 'uploads'
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+app.config.from_object(DefaultConfig)
+os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 
 @app.template_filter('b64encode')
 def b64encode_filter(data):
@@ -124,11 +124,11 @@ def builder():
         pdf.multi_cell(0, 10, txt=f"Experience:\n{experience}")
         pdf.multi_cell(0, 10, txt=f"Education:\n{education}")
 
-        file_path = os.path.join(UPLOAD_FOLDER, "built_resume.pdf")
+        file_path = os.path.join(app.config['UPLOAD_FOLDER'], "built_resume.pdf")
         pdf.output(file_path)
         return send_file(file_path, as_attachment=True)
 
     return render_template("builder.html")
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=app.config['DEBUG'])

--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+class DefaultConfig:
+    DEBUG = True
+    UPLOAD_FOLDER = 'uploads'
+
+class ProductionConfig(DefaultConfig):
+    DEBUG = False


### PR DESCRIPTION
## Summary
- add `config.py` with separate classes for default and production settings
- load settings via `app.config.from_object` in `app.py`

## Testing
- `python -m py_compile app.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68419c85f2f4832ca07f1929c92fa7cf