### PR TITLE
Add basic tests for key routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,12 @@ pip install -r requirements.txt
 # Run the app
 python app.py
 ```
+
+## 🧪 Running Tests
+
+Install `pytest` and run the test suite:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+import importlib
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(scope="session")
+def flask_app():
+    import os, sys
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if root not in sys.path:
+        sys.path.insert(0, root)
+    with patch("sentence_transformers.SentenceTransformer") as MockModel:
+        MockModel.return_value = MagicMock()
+        module = importlib.import_module("app")
+    return module.app
+
+@pytest.fixture
+def client(flask_app):
+    flask_app.config["TESTING"] = True
+    with flask_app.test_client() as client:
+        yield client

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,11 @@
+def test_screener_get(client):
+    resp = client.get('/screener')
+    assert resp.status_code == 200
+    assert b'Resume Screener' in resp.data
+    assert b'Upload Resume' in resp.data
+
+def test_builder_get(client):
+    resp = client.get('/builder')
+    assert resp.status_code == 200
+    assert b'Resume Builder' in resp.data
+    assert b'Full Name' in resp.data


### PR DESCRIPTION
## Summary
- set up pytest fixtures and route tests
- document test execution in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a3da5040832c83dac7fba4c1d402