### PR TITLE
Pin dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ source virtualenv/bin/activate # On macOS/Linux
 # Install dependencies
 pip install -r requirements.txt
 
+# The requirements file pins the library versions used by the app:
+# Flask==3.1.1
+# gunicorn==23.0.0
+# sentence-transformers==4.1.0
+# PyMuPDF==1.26.0
+# python-docx==1.1.2
+# matplotlib==3.10.3
+# fpdf==1.7.2
+
 # Run the app
 python app.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-flask
-gunicorn
-sentence-transformers
-PyMuPDF
-python-docx
-matplotlib
-fpdf
+flask==3.1.1
+gunicorn==23.0.0
+sentence-transformers==4.1.0
+PyMuPDF==1.26.0
+python-docx==1.1.2
+matplotlib==3.10.3
+fpdf==1.7.2


### PR DESCRIPTION
## Summary
- pin dependency versions in requirements.txt
- document the pinned versions in the README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a71caecc832cb7c5c89003627cb9